### PR TITLE
Use IPA to describe pronunciation of "jsFiddle"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,9 @@ Please join to the `jsfiddle-users mailing list
 
 .. note::
    Pronounce it as the single letters "j" and "s", and the word, 
-   "fiddle": /jay ess fid-uhl/ `(English Language & Usage) 
-   <http://english.stackexchange.com/questions/8688/pronunciation-of-jsfiddle>`_
+   "fiddle" (in `IPA`_, /ˈdʒeɪ.ɛs.ˈfɪ.dl/).
+
+.. _IPA: http://en.wikipedia.org/wiki/International_Phonetic_Alphabet
 
 
 Contents:


### PR DESCRIPTION
It is important to be precise when describing pronunciations. The best
way to do so is to use the International Phonetic Alphabet, and not
resort to fudgy phonetic spellings, especially ones based on the
notoriously inaccurate orthography of English.
